### PR TITLE
Re-export `when`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export {
 } from './common';
 
 export {
-  Failable, isFailable
+  Failable, isFailable, when
 } from './failable';
 
 export {


### PR DESCRIPTION
The [README claims that there exists both `Failable.when` and `when`](https://github.com/UrbanDoor/failable#whenfailablet-pending-success-failure--), but `index.ts` doesn't re-export `when`. This change makes that a reality.