### PR TITLE
Pin dependencies and v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failable",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Simplify error state handling",
   "main": "lib/index.js",
   "typings": "lib/index",

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
   },
   "homepage": "https://github.com/UrbanDoor/failable#readme",
   "devDependencies": {
-    "@types/chai": "^3.4.32",
-    "@types/mocha": "^2.2.31",
-    "chai": "^3.5.0",
-    "mocha": "^3.0.2",
-    "ts-node": "^1.3.0",
+    "@types/chai": "3.4.32",
+    "@types/mocha": "2.2.31",
+    "chai": "3.5.0",
+    "mocha": "3.0.2",
+    "ts-node": "1.3.0",
     "typescript": "2.0.2",
-    "typings": "^1.4.0"
+    "typings": "1.4.0"
   }
 }


### PR DESCRIPTION
- Pin dependencies so we have a consistent environment between CI and dev.
- Bump up the version number to v2.1.0, since `when` is technically a new feature that's backwards compatible.