### PR TITLE
Extract dispatch methods into Dispatcher

### DIFF
--- a/src/dispatcher/index.ts
+++ b/src/dispatcher/index.ts
@@ -1,0 +1,81 @@
+export interface Handler<T> {
+  (a: T): any;
+}
+
+export class Dispatcher<State extends string> {
+  private allHandlers: {[key: string]: Handler<any>[]} = {};
+
+  constructor(public validStates: State[]) {
+    const {allHandlers: handlers} = this;
+    for (const state of validStates) {
+      handlers[state as string] = [];
+    }
+  }
+
+  /**
+   * Returns the raw handler array of a given state. This is intended for
+   * low-level utilities, so there is no guard against mutation.
+   */
+  handlersOf(state: State): Handler<any>[] {
+    const handlers = this.allHandlers[state.toLowerCase()];
+
+    if (handlers === undefined) {
+      throw new TypeError(`${state} is not a valid state`);
+    }
+
+    return handlers;
+  }
+
+  /**
+   * Remove every handler for every state. This is behaviorally equivalent to
+   * calling `remove` for each state in existence.
+   */
+  clear(): void {
+    for (const state of this.validStates) {
+      const handlers = this.handlersOf(state);
+      handlers.splice(0, handlers.length);
+    }
+  }
+
+  /**
+   * Given a state and any associated data, invoke all handlers registered under
+   * that state with said data, in the order of registration.
+   */
+  dispatch(state: State, data: any): void {
+    for (const handler of this.handlersOf(state)) {
+      handler(data);
+    }
+  }
+
+  /**
+   * Registers a `handler` to a `state`. This handler is invoked when `dispatch`
+   * is called. To ensure all handlers are invoked, do not throw any errors in
+   * any of the handlers.
+   */
+  addListener(state: State, f: Handler<any>): void {
+    const handlers = this.handlersOf(state);
+
+    handlers.push(f);
+  }
+
+  /**
+   * Unregisters a `handler` from a `state`. If a `handler` is not provided,
+   * every handler is removed from that `state`. To prevent unregistration from
+   * failing silently, store the initial handler and do not define it as an
+   * anonymous function.
+   */
+  removeListener(state: State, f?: Handler<any>): void {
+    const handlers = this.handlersOf(state);
+
+    if (!f) {
+      handlers.splice(0, handlers.length);
+      return;
+    }
+
+    for (let i = 0; i < handlers.length; i++) {
+      if (handlers[i] === f) {
+        handlers.splice(i, 1);
+      }
+    }
+  }
+}

--- a/src/dispatcher/spec/index.spec.ts
+++ b/src/dispatcher/spec/index.spec.ts
@@ -1,0 +1,162 @@
+import {expect} from 'chai';
+
+import {Dispatcher} from '..';
+
+describe('Dispatcher', () => {
+  type ABC = 'a' | 'b' | 'c';
+  const validStates: ABC[] = ['a', 'b', 'c'];
+
+  class ABCD extends Dispatcher<ABC> {
+    constructor() {
+      super(validStates);
+    }
+  }
+
+  describe('constructor', () => {
+    it('constructs directly', () => {
+      expect(() => {
+        new Dispatcher<ABC>(validStates);
+      }).to.not.throw(Error);
+    });
+
+    it('constructs in a subclass', () => {
+      expect(() => {
+        new ABCD();
+      }).to.not.throw(Error);
+    });
+  });
+
+  describe('handlersOf', () => {
+    const d = new ABCD();
+
+    validStates.forEach(state => {
+      it(`returns an array given a '${state}' state`, () => {
+        const result = d.handlersOf(state);
+
+        expect(Array.isArray(result)).to.be.true;
+      });
+    });
+
+    it('throws given an unknown state', () => {
+      expect(() => {
+        (d.handlersOf as Function)('foobar');
+      }).to.throw(TypeError);
+    });
+  });
+
+  describe('clear', () => {
+    const d = new ABCD();
+
+    it('removes handlers for every state', () => {
+      validStates.forEach(state => {
+        d.addListener(state, () => {});
+      });
+
+      validStates.forEach(state => {
+        const handlers = d.handlersOf(state);
+        expect(handlers).to.not.be.empty;
+      });
+
+      d.clear();
+
+      validStates.forEach(state => {
+        const handlers = d.handlersOf(state);
+        expect(handlers).to.be.empty;
+      });
+    });
+  });
+
+  describe('dispatch', () => {
+    const d = new ABCD();
+
+    validStates.forEach(state => {
+      it(`dispatches ${state} handlers`, () => {
+        const result: number[] = [];
+        const handlers = d.handlersOf(state);
+        handlers.push(n => result.push(n + 1));
+        handlers.push(n => result.push(n + 2));
+        handlers.push(n => result.push(n + 3));
+
+        d.dispatch(state, 0);
+
+        expect(result).to.deep.equal([1, 2, 3]);
+      });
+    });
+  });
+
+  describe('addListener', () => {
+    const d = new ABCD();
+    afterEach(() => {
+      d.clear();
+    });
+
+    it("invokes all 'a' handlers when `dispatch` is called with 'a'", () => {
+      const result: number[] = [];
+      d.addListener('a', x => result.push(x + 1));
+      d.addListener('a', x => result.push(x + 2));
+      d.addListener('b', x => result.push(x + 3));
+
+      d.dispatch('a', 0);
+
+      expect(result).to.eql([1, 2]);
+    });
+
+    it("does not invoke 'a' handlers when `dispatch` is called with 'b'", () => {
+      const result: number[] = [];
+      d.addListener('a', x => result.push(x + 1));
+      d.addListener('a', x => result.push(x + 2));
+      d.addListener('b', x => result.push(x + 3));
+
+      d.dispatch('b', 1);
+
+      expect(result).to.not.eql([1, 2]);
+    });
+
+    it('throws when invoked with invalid state', () => {
+      expect(() => {
+        (d.addListener as Function)('foobar', () => {});
+      }).to.throw(TypeError);
+    });
+  });
+
+  describe('removeListener', () => {
+    const d = new ABCD();
+    afterEach(() => {
+      d.clear();
+    });
+
+    const a = (_: any) => {};
+    const b = (_: any) => {};
+    const c = (_: any) => {};
+
+    validStates.forEach(state => {
+      it(`removes a specific ${state} handler`, () => {
+        const handlers = d.handlersOf(state);
+        handlers.push(a);
+        handlers.push(b);
+        handlers.push(c);
+
+        d.removeListener(state, b);
+
+        expect(handlers).to.deep.equal([a, c]);
+      });
+
+      it(`removes all ${state} handlers`, () => {
+        const handlers = d.handlersOf(state);
+        handlers.push(a);
+        handlers.push(b);
+        handlers.push(c);
+
+        d.removeListener(state);
+
+        expect(handlers).to.be.empty;
+      });
+    });
+
+    it('throws when invoked with invalid state', () => {
+      expect(() => {
+        (d.removeListener as Function)('foobar', () => {});
+      }).to.throw(TypeError);
+    });
+  });
+});

--- a/src/failable/spec/index.spec.ts
+++ b/src/failable/spec/index.spec.ts
@@ -3,16 +3,8 @@ import {expect} from 'chai';
 import {Failable} from '..';
 import {success, pending, failure} from '../../common';
 
-function clearAllHandlers(): void {
-  for (const state of states) {
-    const handlers = Failable._handlersOf(state);
-    handlers.splice(0, handlers.length);
-  }
-}
-
 const aSuccess = success(42);
 const aFailure = failure(new Error('no meaning found'));
-const states: Failable.State[] = ['pending', 'failure', 'success'];
 
 describe('Failable.is', () => {
   it('returns true for a success', () => {
@@ -29,114 +21,6 @@ describe('Failable.is', () => {
 
   it('returns false for an empty object', () => {
     expect(Failable.is({})).to.be.false;
-  });
-});
-
-describe('Failable._handlersOf', () => {
-  states.forEach(state => {
-    it(`returns an array given a ${state} state`, () => {
-      const result = Failable._handlersOf(state);
-
-      expect(Array.isArray(result)).to.be.true;
-    });
-  });
-
-  it('throws given an unknown state', () => {
-    expect(() => {
-      const f = Failable._handlersOf as Function;
-      f('foobar');
-    }).to.throw(TypeError);
-  });
-});
-
-describe('Failable.dispatch', () => {
-  states.forEach(state => {
-    it(`dispatches ${state} handlers`, () => {
-      const result: number[] = [];
-      const handlers = Failable._handlersOf(state);
-      handlers.push(n => result.push(n + 1));
-      handlers.push(n => result.push(n + 2));
-      handlers.push(n => result.push(n + 3));
-
-      Failable.dispatch(state, 0);
-
-      expect(result).to.deep.equal([1, 2, 3]);
-    });
-  });
-});
-
-const emptyOptions: Failable.WhenOptions<any, void, void, void> = {
-  success: (_: any) => {},
-  pending: () => {},
-  failure: (_: any) => {}
-};
-
-describe('Failable.addListener', () => {
-  afterEach(clearAllHandlers);
-
-  it('invokes all pending handlers when `when` is called', () => {
-    const result: number[] = [];
-    Failable.addListener('pending', () => result.push(1));
-    Failable.addListener('pending', () => result.push(2));
-
-    Failable.when(pending, emptyOptions);
-
-    expect(result).to.deep.equal([1, 2]);
-  });
-
-  it('invokes all failure handlers when `when` is called', () => {
-    const e1 = new Error();
-    const e2 = new Error();
-    const result: Error[] = [];
-    Failable.addListener('failure', _ => result.push(e1));
-    Failable.addListener('failure', _ => result.push(e2));
-
-    Failable.when(failure(e1), emptyOptions);
-
-    expect(result).to.deep.equal([e1, e2]);
-  });
-
-  it('invokes all success handlers when `when` is called', () => {
-    const value = 5;
-    const result: number[] = [];
-    Failable.addListener('success', (v: number) => result.push(v));
-    Failable.addListener('success', (v: number) => result.push(v + 1));
-
-    Failable.when(success(value), emptyOptions);
-
-    expect(result).to.deep.equal([value, value + 1]);
-  });
-});
-
-describe('Failable.removeListener', () => {
-  afterEach(clearAllHandlers);
-
-  const a = (_: any) => {};
-  const b = (_: any) => {};
-  const c = (_: any) => {};
-
-  states.forEach(state => {
-    it(`removes a specific ${state} handler`, () => {
-      const handlers = Failable._handlersOf(state);
-      handlers.push(a);
-      handlers.push(b);
-      handlers.push(c);
-
-      Failable.removeListener(state, b);
-
-      expect(handlers).to.deep.equal([a, c]);
-    });
-
-    it(`removes all ${state} handlers`, () => {
-      const handlers = Failable._handlersOf(state);
-      handlers.push(a);
-      handlers.push(b);
-      handlers.push(c);
-
-      Failable.removeListener(state);
-
-      expect(handlers).to.be.empty;
-    });
   });
 });
 


### PR DESCRIPTION
The `Failable` namespace contains stateful methods that concern event registration and dispatching. Not only are they intermingled with other methods, but in that arrangement it's not a reusable piece of mechanic.

This change extracts both the dispatcher moving parts as well as its tests out into its own module. The decision not to re-export its constituents through `index.ts` is intentional: this module is for internal consumption.