### PR TITLE
Build system cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,5 @@ node_modules
 # Optional REPL history
 .node_repl_history
 
-# TypeScript typings
-typings
-
 # Compiled code
 lib

--- a/.npmignore
+++ b/.npmignore
@@ -32,8 +32,5 @@ node_modules
 # Optional REPL history
 .node_repl_history
 
-# TypeScript typings
-typings
-
 # TypeScript source files
 src

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,11 @@
+# Publishing
+
+To publish a new version of failable:
+
+1. Make sure you are logged in by running
+   [`npm whoami`](https://docs.npmjs.com/cli/whoami).
+2. Ensure the project builds (`npm run build`) and the tests pass (`npm test`).
+3. Use [`npm version`](https://docs.npmjs.com/cli/version) to bump the version
+   number.
+4. Use the run script `npm run prepare` to build and copy necessary files to `lib`.
+5. Run [`npm publish ./lib`](https://docs.npmjs.com/cli/publish) to publish.

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "failable",
   "version": "2.1.0",
   "description": "Simplify error state handling",
-  "main": "lib/index.js",
-  "typings": "lib/index",
+  "main": "index.js",
+  "typings": "index",
   "scripts": {
     "test": "mocha --require ts-node/register ./src/**/*.spec.ts",
-    "build": "tsc",
-    "prepublish": "npm run build"
+    "build": "rm -r lib; tsc",
+    "prepare": "npm run build && ts-node prepare.ts"
   },
   "repository": {
     "type": "git",
@@ -21,8 +21,10 @@
   "homepage": "https://github.com/UrbanDoor/failable#readme",
   "devDependencies": {
     "@types/chai": "3.4.32",
+    "@types/fs-extra": "0.0.37",
     "@types/mocha": "2.2.39",
     "chai": "3.5.0",
+    "fs-extra": "^2.0.0",
     "mocha": "3.0.2",
     "ts-node": "1.3.0",
     "typescript": "2.1.6"

--- a/package.json
+++ b/package.json
@@ -6,8 +6,6 @@
   "typings": "lib/index",
   "scripts": {
     "test": "mocha --require ts-node/register ./src/**/*.spec.ts",
-    "typings": "typings",
-    "prebuild": "rm -r ./typings; npm run typings -- install",
     "build": "tsc",
     "prepublish": "npm run build"
   },
@@ -23,11 +21,10 @@
   "homepage": "https://github.com/UrbanDoor/failable#readme",
   "devDependencies": {
     "@types/chai": "3.4.32",
-    "@types/mocha": "2.2.31",
+    "@types/mocha": "2.2.39",
     "chai": "3.5.0",
     "mocha": "3.0.2",
     "ts-node": "1.3.0",
-    "typescript": "2.0.2",
-    "typings": "1.4.0"
+    "typescript": "2.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "chai": "3.5.0",
     "mocha": "3.0.2",
     "ts-node": "1.3.0",
-    "typescript": "2.0.2"
+    "typescript": "2.1.6"
   }
 }

--- a/prepare.ts
+++ b/prepare.ts
@@ -1,0 +1,7 @@
+import * as path from 'path';
+import * as fs from 'fs-extra';
+
+const PACKAGE_JSON = 'package.json';
+const LIB_PATH = './lib';
+
+fs.copySync(PACKAGE_JSON, path.join(LIB_PATH, PACKAGE_JSON));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,12 +11,10 @@
     "outDir": "lib/"
   },
   "files": [
-    "./src/index.ts",
-    "./typings/index.d.ts"
+    "./src/index.ts"
   ],
   "filesGlob": [
     "./src/**/*.ts",
-    "./typings/index.d.ts",
     "!./node_modules/**/*.ts",
     "!./node_modules/**/*.tsx"
   ],

--- a/typings.json
+++ b/typings.json
@@ -1,7 +1,0 @@
-{
-  "name": "failable",
-  "dependencies": {},
-  "globalDevDependencies": {
-    "mocha": "registry:dt/mocha#2.2.5+20160720003353"
-  }
-}


### PR DESCRIPTION
This paves the way for https://github.com/UrbanDoor/failable/issues/12. Our goal is that users will be able to do things like `require('failable/core')` without having to resort to something clunky like `require('failable/lib/core')`.