### PR TITLE
Experimental mutable

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "ts-node": "1.3.0",
     "tslint": "4.5.1",
     "typescript": "2.1.6"
+  },
+  "dependencies": {
+    "mobx": "3.1.0"
   }
 }

--- a/src/common/index.spec.ts
+++ b/src/common/index.spec.ts
@@ -3,7 +3,7 @@ import {expect} from 'chai';
 import {
   success, failure, pending,
   isSuccess, isFailure, isPending
-} from '..';
+} from './';
 
 const aSuccess = success(42);
 const aFailure = failure(new Error('no meaning found'));

--- a/src/dispatcher/index.spec.ts
+++ b/src/dispatcher/index.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 
-import {Dispatcher} from '..';
+import {Dispatcher} from './';
 
 describe('Dispatcher', () => {
   type ABC = 'a' | 'b' | 'c';

--- a/src/failable/index.spec.ts
+++ b/src/failable/index.spec.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 
-import {Failable} from '..';
-import {success, pending, failure} from '../../common';
+import {Failable} from './';
+import {success, pending, failure} from '../common';
 
 const aSuccess = success(42);
 const aFailure = failure(new Error('no meaning found'));

--- a/src/mut/index.spec.ts
+++ b/src/mut/index.spec.ts
@@ -1,0 +1,173 @@
+import {expect} from 'chai';
+import {computed, useStrict} from 'mobx';
+
+import {Failable as F} from './';
+
+useStrict(true);
+
+const empty = () => {};
+
+class Failable<T> extends F<T> {
+  @computed get internalData() { return this.data; }
+  @computed get internalState() { return this.state; }
+}
+
+describe('Failable (mutable)', () => {
+  const successValue = 3;
+  const failureValue = new Error();
+  const pending = new Failable<number>();
+  const success = new Failable<number>().success(successValue);
+  const failure = new Failable<number>().failure(failureValue);
+
+  describe('constructor', () => {
+    const f = new Failable<void>();
+
+    it('initializes the state as "pending"', () => {
+      expect(f.internalState.get()).to.eq(Failable.State.pending);
+    });
+  });
+
+  describe('success', () => {
+    it('sets the internal state to "success"', () => {
+      expect(success.internalState.get()).to.eq(Failable.State.success);
+    });
+
+    it('sets the internal data to the given value', () => {
+      expect(success.internalData.get()).to.eq(successValue);
+    });
+  });
+
+  describe('failure', () => {
+    it('sets the internal state to "failure"', () => {
+      expect(failure.internalState.get()).to.eq(Failable.State.failure);
+    });
+
+    it('sets the internal data to the given value', () => {
+      expect(failure.internalData.get()).to.eq(failureValue);
+    });
+  });
+
+  describe('pending', () => {
+    const f = new Failable<number>().pending();
+
+    it('sets the internal state to "pending"', () => {
+      expect(f.internalState.get()).to.eq(Failable.State.pending);
+    });
+  });
+
+  describe('isSuccess', () => {
+    it('is true when success', () => {
+      expect(success.isSuccess).to.be.true;
+    });
+
+    it('is false when failure', () => {
+      expect(success.isFailure).to.be.false;
+    });
+
+    it('is false when pending', () => {
+      expect(success.isPending).to.be.false;
+    });
+  });
+
+  describe('isFailure', () => {
+    it('is false when success', () => {
+      expect(failure.isSuccess).to.be.false;
+    });
+
+    it('is true when failure', () => {
+      expect(failure.isFailure).to.be.true;
+    });
+
+    it('is false when pending', () => {
+      expect(failure.isPending).to.be.false;
+    });
+  });
+
+  describe('isPending', () => {
+    it('is false when success', () => {
+      expect(pending.isSuccess).to.be.false;
+    });
+
+    it('is false when failure', () => {
+      expect(pending.isFailure).to.be.false;
+    });
+
+    it('is true when pending', () => {
+      expect(pending.isPending).to.be.true;
+    });
+  });
+
+  describe('match', () => {
+    it('invokes the pending handler', () => {
+      let called = false;
+      pending.match({
+        pending: () => called = true,
+        success: empty,
+        failure: empty
+      });
+
+      expect(called).to.be.true;
+    });
+
+    it('does not invoke other handlers when pending', () => {
+      const result: boolean[] = [];
+      pending.match({
+        pending: empty,
+        success: (_data) => result.push(true),
+        failure: (_error) => result.push(true)
+      });
+
+      expect(result).to.be.empty;
+    });
+
+    it('invokes the success handler with the correct value', () => {
+      let called = false;
+      success.match({
+        pending: empty,
+        success: (data) => {
+          called = true;
+          expect(data).to.eq(successValue);
+        },
+        failure: empty
+      });
+
+      expect(called).to.be.true;
+    });
+
+    it('does not invoke other handlers when success', () => {
+      const result: boolean[] = [];
+      success.match({
+        pending: () => result.push(true),
+        success: empty,
+        failure: (_error) => result.push(true)
+      });
+
+      expect(result).to.be.empty;
+    });
+
+    it('invokes the failure handler', () => {
+      let called = false;
+      failure.match({
+        pending: empty,
+        success: empty,
+        failure: (error) => {
+          called = true;
+          expect(error).to.eq(failureValue);
+        }
+      });
+
+      expect(called).to.be.true;
+    });
+
+    it('does not invoke other handlers when failure', () => {
+      const result: boolean[] = [];
+      failure.match({
+        pending: () => result.push(true),
+        success: (_data) => result.push(true),
+        failure: empty
+      });
+
+      expect(result).to.be.empty;
+    });
+  });
+});

--- a/src/mut/index.spec.ts
+++ b/src/mut/index.spec.ts
@@ -11,8 +11,8 @@ useStrict(true);
 
 describe('Failable (mutable)', () => {
   class Failable<T> extends F<T> {
-    @computed get internalData() { return this.data; }
-    @computed get internalState() { return this.state; }
+    @computed get internalData(): T | Error | undefined { return this.data; }
+    @computed get internalState(): F.State { return this.state; }
 
     calledSuccess = false;
     didBecomeSuccess(_: T) { this.calledSuccess = true; }
@@ -28,7 +28,7 @@ describe('Failable (mutable)', () => {
     const f = new Failable<void>();
 
     it('initializes the state as "pending"', () => {
-      expect(f.internalState.get()).to.eq(Failable.State.pending);
+      expect(f.internalState).to.eq(Failable.State.pending);
     });
   });
 
@@ -37,11 +37,11 @@ describe('Failable (mutable)', () => {
     beforeEach(() => f = new Failable<number>().success(successValue));
 
     it('sets the internal state to "success"', () => {
-      expect(f.internalState.get()).to.eq(Failable.State.success);
+      expect(f.internalState).to.eq(Failable.State.success);
     });
 
     it('sets the internal data to the given value', () => {
-      expect(f.internalData.get()).to.eq(successValue);
+      expect(f.internalData).to.eq(successValue);
     });
 
     it('invokes didBecomeSuccess', () => {
@@ -56,11 +56,11 @@ describe('Failable (mutable)', () => {
     beforeEach(() => f = new Failable<number>().failure(failureValue));
 
     it('sets the internal state to "failure"', () => {
-      expect(f.internalState.get()).to.eq(Failable.State.failure);
+      expect(f.internalState).to.eq(Failable.State.failure);
     });
 
     it('sets the internal data to the given value', () => {
-      expect(f.internalData.get()).to.eq(failureValue);
+      expect(f.internalData).to.eq(failureValue);
     });
 
     it('invokes didBecomeFailure', () => {
@@ -75,7 +75,7 @@ describe('Failable (mutable)', () => {
     beforeEach(() => f = new Failable<number>().pending());
 
     it('sets the internal state to "pending"', () => {
-      expect(f.internalState.get()).to.eq(Failable.State.pending);
+      expect(f.internalState).to.eq(Failable.State.pending);
     });
 
     it('invokes didBecomePending', () => {

--- a/src/mut/index.spec.ts
+++ b/src/mut/index.spec.ts
@@ -24,10 +24,6 @@ describe('Failable (mutable)', () => {
     didBecomePending() { this.calledPending = true; }
   }
 
-  const pending = new Failable<number>();
-  const success = new Failable<number>().success(successValue);
-  const failure = new Failable<number>().failure(failureValue);
-
   describe('constructor', () => {
     const f = new Failable<void>();
 
@@ -37,39 +33,46 @@ describe('Failable (mutable)', () => {
   });
 
   describe('success', () => {
+    let f: Failable<number>;
+    beforeEach(() => f = new Failable<number>().success(successValue));
+
     it('sets the internal state to "success"', () => {
-      expect(success.internalState.get()).to.eq(Failable.State.success);
+      expect(f.internalState.get()).to.eq(Failable.State.success);
     });
 
     it('sets the internal data to the given value', () => {
-      expect(success.internalData.get()).to.eq(successValue);
+      expect(f.internalData.get()).to.eq(successValue);
     });
 
     it('invokes didBecomeSuccess', () => {
-      expect(success.calledSuccess).to.be.true;
-      expect(success.calledFailure).to.be.false;
-      expect(success.calledPending).to.be.false;
+      expect(f.calledSuccess).to.be.true;
+      expect(f.calledFailure).to.be.false;
+      expect(f.calledPending).to.be.false;
     });
   });
 
   describe('failure', () => {
+    let f: Failable<number>;
+    beforeEach(() => f = new Failable<number>().failure(failureValue));
+
     it('sets the internal state to "failure"', () => {
-      expect(failure.internalState.get()).to.eq(Failable.State.failure);
+      expect(f.internalState.get()).to.eq(Failable.State.failure);
     });
 
     it('sets the internal data to the given value', () => {
-      expect(failure.internalData.get()).to.eq(failureValue);
+      expect(f.internalData.get()).to.eq(failureValue);
     });
 
     it('invokes didBecomeFailure', () => {
-      expect(failure.calledSuccess).to.be.false;
-      expect(failure.calledFailure).to.be.true;
-      expect(failure.calledPending).to.be.false;
+      expect(f.calledSuccess).to.be.false;
+      expect(f.calledFailure).to.be.true;
+      expect(f.calledPending).to.be.false;
     });
   });
 
   describe('pending', () => {
-    const f = new Failable<number>().pending();
+    let f: Failable<number>;
+    beforeEach(() => f = new Failable<number>().pending());
 
     it('sets the internal state to "pending"', () => {
       expect(f.internalState.get()).to.eq(Failable.State.pending);
@@ -83,48 +86,61 @@ describe('Failable (mutable)', () => {
   });
 
   describe('isSuccess', () => {
+    let f: Failable<number>;
+    beforeEach(() => f = new Failable<number>().success(successValue));
+
     it('is true when success', () => {
-      expect(success.isSuccess).to.be.true;
+      expect(f.isSuccess).to.be.true;
     });
 
     it('is false when failure', () => {
-      expect(success.isFailure).to.be.false;
+      expect(f.isFailure).to.be.false;
     });
 
     it('is false when pending', () => {
-      expect(success.isPending).to.be.false;
+      expect(f.isPending).to.be.false;
     });
   });
 
   describe('isFailure', () => {
+    let f: Failable<number>;
+    beforeEach(() => f = new Failable<number>().failure(failureValue));
+
     it('is false when success', () => {
-      expect(failure.isSuccess).to.be.false;
+      expect(f.isSuccess).to.be.false;
     });
 
     it('is true when failure', () => {
-      expect(failure.isFailure).to.be.true;
+      expect(f.isFailure).to.be.true;
     });
 
     it('is false when pending', () => {
-      expect(failure.isPending).to.be.false;
+      expect(f.isPending).to.be.false;
     });
   });
 
   describe('isPending', () => {
+    let f: Failable<number>;
+    beforeEach(() => f = new Failable<number>().pending());
+
     it('is false when success', () => {
-      expect(pending.isSuccess).to.be.false;
+      expect(f.isSuccess).to.be.false;
     });
 
     it('is false when failure', () => {
-      expect(pending.isFailure).to.be.false;
+      expect(f.isFailure).to.be.false;
     });
 
     it('is true when pending', () => {
-      expect(pending.isPending).to.be.true;
+      expect(f.isPending).to.be.true;
     });
   });
 
   describe('match', () => {
+    const pending = new Failable<number>();
+    const success = new Failable<number>().success(successValue);
+    const failure = new Failable<number>().failure(failureValue);
+
     it('invokes the pending handler', () => {
       let called = false;
       pending.match({

--- a/src/mut/index.ts
+++ b/src/mut/index.ts
@@ -36,6 +36,7 @@ export class Failable<T> {
   /**
    * Sets this Failable to a success.
    * @param data The value associated with the success.
+   * @returns This, enabling chaining.
    */
   @action.bound success(data: T): this {
     this.state.set(State.success);
@@ -53,6 +54,7 @@ export class Failable<T> {
   /**
    * Sets this Failable to a failure.
    * @param error The error associated with the failure.
+   * @returns This, enabling chaining.
    */
   @action.bound failure(error: Error): this {
     this.state.set(State.failure);
@@ -69,6 +71,7 @@ export class Failable<T> {
 
   /**
    * Sets this Failable to pending.
+   * @returns This, enabling chaining.
    */
   @action.bound pending(): this {
     this.state.set(State.pending);
@@ -85,9 +88,9 @@ export class Failable<T> {
 
   /**
    * Invokes one of the provided callbacks that corresponds this Failable's
-   * current state, and passes along the return value of whichever callback
-   * was selected.
+   * current state.
    * @param options An object of callbacks to be invoked according to the state.
+   * @returns The return value of whichever callback was selected.
    */
   match<A, B, C>(options: Failable.MatchOptions<T, A, B, C>): A | B | C {
     const data = this.data.get();

--- a/src/mut/index.ts
+++ b/src/mut/index.ts
@@ -1,4 +1,4 @@
-import {IObservableValue, observable, action, computed} from 'mobx';
+import {observable, action, computed} from 'mobx';
 
 /**
  * Failable is a reactive MobX counterpart to a Promise. It has three states:
@@ -10,28 +10,23 @@ import {IObservableValue, observable, action, computed} from 'mobx';
  * but for day-to-day usage, prefer the `match` method.
  */
 export class Failable<T> {
-  protected data: IObservableValue<T | Error | undefined>;
-  protected state: IObservableValue<Failable.State>;
-
-  constructor() {
-    this.data = observable.box(undefined, 'data');
-    this.state = observable.box<Failable.State>(State.pending, 'state');
-  }
+  @observable protected data: T | Error | undefined = undefined;
+  @observable protected state: Failable.State = State.pending;
 
   /**
    * Indicates if this Failable is a success.
    */
-  @computed get isSuccess(): boolean { return this.state.get() === State.success; }
+  @computed get isSuccess(): boolean { return this.state === State.success; }
 
   /**
    * Indicates if this Failable is a failure.
    */
-  @computed get isFailure(): boolean { return this.state.get() === State.failure; }
+  @computed get isFailure(): boolean { return this.state === State.failure; }
 
   /**
    * Indicates if this Failable is pending.
    */
-  @computed get isPending(): boolean { return this.state.get() === State.pending; }
+  @computed get isPending(): boolean { return this.state === State.pending; }
 
   /**
    * Sets this Failable to a success.
@@ -39,8 +34,8 @@ export class Failable<T> {
    * @returns This, enabling chaining.
    */
   @action.bound success(data: T): this {
-    this.state.set(State.success);
-    this.data.set(data);
+    this.state = State.success;
+    this.data = data;
     this.didBecomeSuccess(data);
     return this;
   }
@@ -57,8 +52,8 @@ export class Failable<T> {
    * @returns This, enabling chaining.
    */
   @action.bound failure(error: Error): this {
-    this.state.set(State.failure);
-    this.data.set(error);
+    this.state = State.failure;
+    this.data = error;
     this.didBecomeFailure(error);
     return this;
   }
@@ -74,8 +69,8 @@ export class Failable<T> {
    * @returns This, enabling chaining.
    */
   @action.bound pending(): this {
-    this.state.set(State.pending);
-    this.data.set(undefined);
+    this.state = State.pending;
+    this.data = undefined;
     this.didBecomePending();
     return this;
   }
@@ -93,10 +88,10 @@ export class Failable<T> {
    * @returns The return value of whichever callback was selected.
    */
   match<A, B, C>(options: Failable.MatchOptions<T, A, B, C>): A | B | C {
-    const data = this.data.get();
+    const data = this.data;
     const {success, failure, pending} = options;
 
-    switch (this.state.get()) {
+    switch (this.state) {
       case State.success: return success(data as T);
       case State.failure: return failure(data as Error);
       case State.pending: return pending();

--- a/src/mut/index.ts
+++ b/src/mut/index.ts
@@ -1,0 +1,113 @@
+import {IObservableValue, observable, action, computed} from 'mobx';
+
+/**
+ * Failable is a reactive MobX counterpart to a Promise. It has three states:
+ * pending, success, and failure. When constructed, it starts out in the pending
+ * state.
+ *
+ * The action methods `success`, `failure`, and `pending` are used to change
+ * between these states. The computed properties indicate the current state,
+ * but for day-to-day usage, prefer the `match` method.
+ */
+export class Failable<T> {
+  protected data: IObservableValue<T | Error | undefined>;
+  protected state: IObservableValue<Failable.State>;
+
+  constructor() {
+    this.data = observable.box(undefined, 'data');
+    this.state = observable.box<Failable.State>(State.pending, 'state');
+  }
+
+  /**
+   * Indicates if this Failable is a success.
+   */
+  @computed get isSuccess(): boolean { return this.state.get() === State.success; }
+
+  /**
+   * Indicates if this Failable is a failure.
+   */
+  @computed get isFailure(): boolean { return this.state.get() === State.failure; }
+
+  /**
+   * Indicates if this Failable is pending.
+   */
+  @computed get isPending(): boolean { return this.state.get() === State.pending; }
+
+  /**
+   * Sets this Failable to a success.
+   * @param data The value associated with the success.
+   */
+  @action.bound success(data: T): this {
+    this.state.set(State.success);
+    this.data.set(data);
+    return this;
+  }
+
+  /**
+   * Sets this Failable to a failure.
+   * @param error The error associated with the failure.
+   */
+  @action.bound failure(error: Error): this {
+    this.state.set(State.failure);
+    this.data.set(error);
+    return this;
+  }
+
+  /**
+   * Sets this Failable to pending.
+   */
+  @action.bound pending(): this {
+    this.state.set(State.pending);
+    this.data.set(undefined);
+    return this;
+  }
+
+  /**
+   * Invokes one of the provided callbacks that corresponds this Failable's
+   * current state, and passes along the return value of whichever callback
+   * was selected.
+   * @param options An object of callbacks to be invoked according to the state.
+   */
+  match<A, B, C>(options: Failable.MatchOptions<T, A, B, C>): A | B | C {
+    const data = this.data.get();
+    const {success, failure, pending} = options;
+
+    switch (this.state.get()) {
+      case State.success: return success(data as T);
+      case State.failure: return failure(data as Error);
+      case State.pending: return pending();
+    }
+  }
+}
+
+export namespace Failable {
+  /**
+   * State represents the three possible states that a Failable can fall under.
+   */
+  export type State = State.Pending | State.Success | State.Failure;
+
+  export namespace State {
+    export const pending = 'pending';
+    export type Pending = typeof pending;
+
+    export const success = 'success';
+    export type Success = typeof success;
+
+    export const failure = 'failure';
+    export type Failure = typeof failure;
+  }
+
+  /**
+   * MatchOptions is an object filled with callbacks. The `success` callback
+   * receives whatever success value was just set. The `failure` callback
+   * receives whatever error was just set. The `pending` callback does not
+   * receive any values.
+   */
+  export interface MatchOptions<T, A, B, C> {
+    success: (data: T) => A;
+    failure: (error: Error) => B;
+    pending: () => C;
+  }
+}
+
+const State = Failable.State;

--- a/src/mut/index.ts
+++ b/src/mut/index.ts
@@ -97,6 +97,19 @@ export class Failable<T> {
       case State.pending: return pending();
     }
   }
+
+  /**
+   * Accepts a promise by immediately setting this Failable to pending, and then
+   * either setting this Failable to a success if the promise was fulfilled, or
+   * setting this Failable to a failure if the promise was rejected.
+   * @param promise A promise to be accepted
+   * @returns This, enabling chaining.
+   */
+  accept(promise: PromiseLike<T>): this {
+    this.pending();
+    Promise.resolve(promise).then(this.success, this.failure);
+    return this;
+  }
 }
 
 export namespace Failable {

--- a/src/mut/index.ts
+++ b/src/mut/index.ts
@@ -1,20 +1,15 @@
 import {IObservableValue, observable, action, computed} from 'mobx';
 
 /**
- * AbstractFailable is an imcomplete superclass of Failable designed to work
- * around TypeScript-related subclassing issues.
+ * Failable is a reactive MobX counterpart to a Promise. It has three states:
+ * pending, success, and failure. When constructed, it starts out in the pending
+ * state.
  *
- * When MobX creates an action on a property, it defines a setter on that
- * property to prevent any external consumers from overwriting that property.
- * This directly clashes with the way TypeScript emits subclassing code below
- * ES6. The net effect is that any class method decorated as a MobX action
- * cannot be overridden in TypeScript. The compilation will succeed, but at
- * runtime it violates the MobX invariant and fails.
- *
- * Curiously, attempting this with a native Node class succeeds, which indicates
- * a difference in how subclasses are implemented across runtimes.
+ * The action methods `success`, `failure`, and `pending` are used to change
+ * between these states. The computed properties indicate the current state,
+ * but for day-to-day usage, prefer the `match` method.
  */
-export class AbstractFailable<T> {
+export class Failable<T> {
   protected data: IObservableValue<T | Error | undefined>;
   protected state: IObservableValue<Failable.State>;
 
@@ -42,30 +37,51 @@ export class AbstractFailable<T> {
    * Sets this Failable to a success.
    * @param data The value associated with the success.
    */
-  protected success(data: T): this {
+  @action.bound success(data: T): this {
     this.state.set(State.success);
     this.data.set(data);
+    this.didBecomeSuccess(data);
     return this;
   }
+
+  /**
+   * A lifecycle method that is invoked after this Failable becomes a success.
+   * This can be overridden in a subclass.
+   */
+  protected didBecomeSuccess(_data: T): void {}
 
   /**
    * Sets this Failable to a failure.
    * @param error The error associated with the failure.
    */
-  protected failure(error: Error): this {
+  @action.bound failure(error: Error): this {
     this.state.set(State.failure);
     this.data.set(error);
+    this.didBecomeFailure(error);
     return this;
   }
 
   /**
+   * A lifecycle method that is invoked after this Failable becomes a success.
+   * This can be overridden in a subclass.
+   */
+  protected didBecomeFailure(_error: Error): void {}
+
+  /**
    * Sets this Failable to pending.
    */
-  protected pending(): this {
+  @action.bound pending(): this {
     this.state.set(State.pending);
     this.data.set(undefined);
+    this.didBecomePending();
     return this;
   }
+
+  /**
+   * A lifecycle method that is invoked after this Failable becomes pending.
+   * This can be overridden in a subclass.
+   */
+  protected didBecomePending(): void {}
 
   /**
    * Invokes one of the provided callbacks that corresponds this Failable's
@@ -82,40 +98,6 @@ export class AbstractFailable<T> {
       case State.failure: return failure(data as Error);
       case State.pending: return pending();
     }
-  }
-}
-
-/**
- * Failable is a reactive MobX counterpart to a Promise. It has three states:
- * pending, success, and failure. When constructed, it starts out in the pending
- * state.
- *
- * The action methods `success`, `failure`, and `pending` are used to change
- * between these states. The computed properties indicate the current state,
- * but for day-to-day usage, prefer the `match` method.
- */
-export class Failable<T> extends AbstractFailable<T> {
-  /**
-   * Sets this Failable to a success.
-   * @param data The value associated with the success.
-   */
-  @action.bound public success(data: T): this {
-    return super.success(data);
-  }
-
-  /**
-   * Sets this Failable to a failure.
-   * @param error The error associated with the failure.
-   */
-  @action.bound public failure(error: Error): this {
-    return super.failure(error);
-  }
-
-  /**
-   * Sets this Failable to pending.
-   */
-  @action.bound public pending(): this {
-    return super.pending();
   }
 }
 

--- a/src/result/index.spec.ts
+++ b/src/result/index.spec.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 
-import {Result} from '..';
-import {isSuccess, isFailure} from '../../common';
+import {Result} from './';
+import {isSuccess, isFailure} from '../common';
 
 describe('Result.from', () => {
   it('produces a Success<T> when the function returns without throwing', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
+    "lib": ["es5", "es2015.promise"],
     "module": "commonjs",
     "declaration": true,
     "strictNullChecks": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "declaration": true,
     "strictNullChecks": true,
+    "experimentalDecorators": true,
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
Implements #14. Introduces a mutable version of `Failable` that works with more ergonomically with MobX.

## Initialization
```ts
// Before
let user: Failable<User> = pending;

// After
const user = new Failable<User>();
```

## "Mutation"
```ts
// Before
user = success(userResponseObject);

// After
user.success(userResponseObject);
```

## Binding to Promise
```ts
// Before
const promise = fetchUser();
user = pending;
promise.then(data => {
  user = success(data);
}, error => {
  user = failure(error)
});

// After
const promise = fetchUser();
user.pending();
promise.then(
  user.success,
  user.failure
);

// After, using `accept`:
const promise = fetchUser();
user.accept(promise);
```

## Detecting State
```ts
// Before
if (isPending(user)) {
  ...
}

// After
if (user.isPending) {
  ...
}
```

## Handling States
```ts
// Before
const result = Failable.when(user, {
  pending: () => ...,
  success: data => ...,
  failure: error => ...
});

// After
const result = user.match({
  pending: () => ...,
  success: data => ...,
  failure: error => ...
});
```

## Reporting Errors
```ts
// Before
// Run once:
Failable.addListener('failure', error => {
  Raven.captureException(error);
});

let user = pending;
...;
const result = Failable.when(user, {
  pending: () => ...,
  success: data => ...,
  failure: error => ...
});
// The above call will trigger the failure listener if `user` is a failure.

// After
// Subclass once:
class MyFailable<T> extends Failable<T> {
  didBecomeFailure(error: Error): void {
    Raven.captureException(error);
  }
}

const user = new MyFailable<User>();
...;
// Any call to `user.failure` will trigger the `captureException` call.
```