### PR TITLE
failable/mut helper methods

### DIFF
--- a/src/mut/failable.spec.ts
+++ b/src/mut/failable.spec.ts
@@ -240,7 +240,7 @@ describe('Failable (mutable)', () => {
   });
 
   describe('failureOr', () => {
-    const fallback = new Error();
+    const fallback = 'foo';
 
     it('returns the fallback when success', () => {
       const result = make.success().failureOr(fallback);

--- a/src/mut/failable.spec.ts
+++ b/src/mut/failable.spec.ts
@@ -213,4 +213,54 @@ describe('Failable (mutable)', () => {
       );
     });
   });
+
+  describe('successOr', () => {
+    const fallback = 4;
+
+    it('returns the value when success', () => {
+      const result = make.success().successOr(fallback);
+
+      expect(result).to.eql(successValue);
+      expect(result).to.not.eql(fallback);
+    });
+
+    it('returns the fallback when failure', () => {
+      const result = make.failure().successOr(fallback);
+
+      expect(result).to.not.eql(successValue);
+      expect(result).to.eql(fallback);
+    });
+
+    it('returns the fallback when pending', () => {
+      const result = make.pending().successOr(fallback);
+
+      expect(result).to.not.eql(successValue);
+      expect(result).to.eql(fallback);
+    });
+  });
+
+  describe('failureOr', () => {
+    const fallback = new Error();
+
+    it('returns the fallback when success', () => {
+      const result = make.success().failureOr(fallback);
+
+      expect(result).to.not.eq(failureValue);
+      expect(result).to.eq(fallback);
+    });
+
+    it('returns the error when failure', () => {
+      const result = make.failure().failureOr(fallback);
+
+      expect(result).to.eq(failureValue);
+      expect(result).to.not.eq(fallback);
+    });
+
+    it('returns the fallback when pending', () => {
+      const result = make.pending().failureOr(fallback);
+
+      expect(result).to.not.eq(failureValue);
+      expect(result).to.eq(fallback);
+    });
+  });
 });

--- a/src/mut/failable.spec.ts
+++ b/src/mut/failable.spec.ts
@@ -215,7 +215,7 @@ describe('Failable (mutable)', () => {
   });
 
   describe('successOr', () => {
-    const fallback = 4;
+    const fallback = 'foo';
 
     it('returns the value when success', () => {
       const result = make.success().successOr(fallback);

--- a/src/mut/failable.ts
+++ b/src/mut/failable.ts
@@ -136,15 +136,15 @@ export class Failable<T> implements Future<T> {
 
   /**
    * Returns this Failable's error value if it is a failure, or the provided
-   * default error if it is not.
-   * @param defaultError A possibly lazy error to use in case of non-failure
-   * @returns this Future's failure error or the provided default error
+   * default value if it is not.
+   * @param defaultValue A possibly lazy value to use in case of non-failure
+   * @returns this Failable's failure error or the provided default value
    */
-  failureOr(defaultError: Lazy<Error>): Error {
+  failureOr<U>(defaultValue: Lazy<U>): Error | U {
     return this.match({
-      success: () => Lazy.force(defaultError),
+      success: () => Lazy.force(defaultValue),
       failure: e => e,
-      pending: () => Lazy.force(defaultError)
+      pending: () => Lazy.force(defaultValue)
     });
   }
 }

--- a/src/mut/failable.ts
+++ b/src/mut/failable.ts
@@ -126,7 +126,7 @@ export class Failable<T> implements Future<T> {
    * @param defaultValue A possibly lazy value to use in case of non-success
    * @returns This Future's success value or the provided default value
    */
-  successOr(defaultValue: Lazy<T>): T {
+  successOr<U>(defaultValue: Lazy<U>): T | U {
     return this.match({
       success: v => v,
       failure: () => Lazy.force(defaultValue),

--- a/src/mut/future.ts
+++ b/src/mut/future.ts
@@ -1,4 +1,5 @@
 import {Enum} from 'typescript-string-enums';
+import {Lazy} from './lazy';
 
 /**
  * Future is a reactive counterpart to a Promise with MobX semantics. It has
@@ -60,6 +61,22 @@ export interface Future<T> {
    * @returns This, enabling chaining.
    */
   accept(promise: PromiseLike<T>): this;
+
+  /**
+   * Returns this Future's success value if it is a success, or the provided
+   * default value if it is not.
+   * @param defaultValue A possibly lazy value to use in case of non-success
+   * @returns This Future's success value or the provided default value
+   */
+  successOr(defaultValue: Lazy<T>): T;
+
+  /**
+   * Returns this Future's error value if it is a failure, or the provided
+   * default error if it is not.
+   * @param defaultError A possibly lazy error to use in case of non-failure
+   * @returns this Future's failure error or the provided default error
+   */
+  failureOr(defaultError: Lazy<Error>): Error;
 }
 
 export namespace Future {

--- a/src/mut/future.ts
+++ b/src/mut/future.ts
@@ -72,11 +72,11 @@ export interface Future<T> {
 
   /**
    * Returns this Future's error value if it is a failure, or the provided
-   * default error if it is not.
-   * @param defaultError A possibly lazy error to use in case of non-failure
-   * @returns this Future's failure error or the provided default error
+   * default value if it is not.
+   * @param defaultValue A possibly lazy value to use in case of non-failure
+   * @returns this Future's failure error or the provided default value
    */
-  failureOr(defaultError: Lazy<Error>): Error;
+  failureOr<U>(defaultValue: Lazy<U>): Error | U;
 }
 
 export namespace Future {

--- a/src/mut/future.ts
+++ b/src/mut/future.ts
@@ -68,7 +68,7 @@ export interface Future<T> {
    * @param defaultValue A possibly lazy value to use in case of non-success
    * @returns This Future's success value or the provided default value
    */
-  successOr(defaultValue: Lazy<T>): T;
+  successOr<U>(defaultValue: Lazy<U>): T | U;
 
   /**
    * Returns this Future's error value if it is a failure, or the provided

--- a/src/mut/index.ts
+++ b/src/mut/index.ts
@@ -1,3 +1,4 @@
 export * from './future';
+export * from './lazy';
 export * from './failable';
 export * from './loadable';

--- a/src/mut/lazy.spec.ts
+++ b/src/mut/lazy.spec.ts
@@ -1,0 +1,26 @@
+import {expect, use} from 'chai';
+import sinon = require('sinon');
+import sinonChai = require('sinon-chai');
+
+import {Lazy} from './lazy';
+
+use(sinonChai);
+
+describe('Lazy', () => {
+  describe('force', () => {
+    it('returns the value as-is when given a non-function', () => {
+      const v = 3;
+      const l: Lazy<number> = v;
+
+      expect(Lazy.force(l)).to.eql(v);
+    });
+
+    it('invokes the function and returns its result when given one', () => {
+      const v = 3;
+      const l: Lazy<number> = sinon.spy(() => v);
+
+      expect(Lazy.force(l)).to.eql(v);
+      expect(l).to.have.been.calledOnce;
+    });
+  });
+});

--- a/src/mut/lazy.ts
+++ b/src/mut/lazy.ts
@@ -1,0 +1,18 @@
+/**
+ * A type that denotes an existing value or a function that, when invoked,
+ * produces a value. Note that the value's type cannot also be a function.
+ */
+export type Lazy<T> = T | (() => T);
+
+export namespace Lazy {
+  /**
+   * Forces the given possibly lazy value to evaluate. If the given value is
+   * lazy (a function), invokes the function and returns that result. If not,
+   * returns the value as-is.
+   * @param v A possibly lazy value
+   * @returns The result of evaluation
+   */
+  export function force<T>(v: Lazy<T>): T {
+    return v instanceof Function ? v() : v;
+  }
+}

--- a/src/mut/loadable.spec.ts
+++ b/src/mut/loadable.spec.ts
@@ -317,4 +317,96 @@ describe('Loadable (mutable)', () => {
       );
     });
   });
+
+  describe('successOr', () => {
+    const fallback = 4;
+
+    it('returns the value when success', () => {
+      const result = make.success().successOr(fallback);
+
+      expect(result).to.eql(successValue);
+      expect(result).to.not.eql(fallback);
+    });
+
+    it('returns the value when reloading', () => {
+      const result = make.reloading().successOr(fallback);
+
+      expect(result).to.eql(successValue);
+      expect(result).to.not.eql(fallback);
+    });
+
+    it('returns the fallback when failure', () => {
+      const result = make.failure().successOr(fallback);
+
+      expect(result).to.not.eql(successValue);
+      expect(result).to.eql(fallback);
+    });
+
+    it('returns the fallback when retrying', () => {
+      const result = make.retrying().successOr(fallback);
+
+      expect(result).to.not.eql(successValue);
+      expect(result).to.eql(fallback);
+    });
+
+    it('returns the fallback when empty', () => {
+      const result = make.empty().successOr(fallback);
+
+      expect(result).to.not.eql(successValue);
+      expect(result).to.eql(fallback);
+    });
+
+    it('returns the fallback when pending', () => {
+      const result = make.pending().successOr(fallback);
+
+      expect(result).to.not.eql(successValue);
+      expect(result).to.eql(fallback);
+    });
+  });
+
+  describe('failureOr', () => {
+    const fallback = new Error();
+
+    it('returns the fallback when success', () => {
+      const result = make.success().failureOr(fallback);
+
+      expect(result).to.not.eq(failureValue);
+      expect(result).to.eq(fallback);
+    });
+
+    it('returns the fallback when reloading', () => {
+      const result = make.reloading().failureOr(fallback);
+
+      expect(result).to.not.eq(failureValue);
+      expect(result).to.eq(fallback);
+    });
+
+    it('returns the error when failure', () => {
+      const result = make.failure().failureOr(fallback);
+
+      expect(result).to.eq(failureValue);
+      expect(result).to.not.eq(fallback);
+    });
+
+    it('returns the error when retrying', () => {
+      const result = make.retrying().failureOr(fallback);
+
+      expect(result).to.eq(failureValue);
+      expect(result).to.not.eq(fallback);
+    });
+
+    it('returns the fallback when empty', () => {
+      const result = make.empty().failureOr(fallback);
+
+      expect(result).to.not.eq(failureValue);
+      expect(result).to.eq(fallback);
+    });
+
+    it('returns the fallback when pending', () => {
+      const result = make.pending().failureOr(fallback);
+
+      expect(result).to.not.eq(failureValue);
+      expect(result).to.eq(fallback);
+    });
+  });
 });

--- a/src/mut/loadable.spec.ts
+++ b/src/mut/loadable.spec.ts
@@ -365,7 +365,7 @@ describe('Loadable (mutable)', () => {
   });
 
   describe('failureOr', () => {
-    const fallback = new Error();
+    const fallback = 'foo';
 
     it('returns the fallback when success', () => {
       const result = make.success().failureOr(fallback);

--- a/src/mut/loadable.spec.ts
+++ b/src/mut/loadable.spec.ts
@@ -319,7 +319,7 @@ describe('Loadable (mutable)', () => {
   });
 
   describe('successOr', () => {
-    const fallback = 4;
+    const fallback = 'foo';
 
     it('returns the value when success', () => {
       const result = make.success().successOr(fallback);

--- a/src/mut/loadable.ts
+++ b/src/mut/loadable.ts
@@ -183,15 +183,15 @@ export class Loadable<T> implements Future<T> {
 
   /**
    * Returns this Loadable's error value if it is a failure, or the provided
-   * default error if it is not.
-   * @param defaultError A possibly lazy error to use in case of non-failure
-   * @returns this Future's failure error or the provided default error
+   * default value if it is not.
+   * @param defaultValue A possibly lazy value to use in case of non-failure
+   * @returns this Loadable's failure error or the provided default value
    */
-  failureOr(defaultError: Lazy<Error>): Error {
+  failureOr<U>(defaultValue: Lazy<U>): Error | U {
     return this.match({
-      success: () => Lazy.force(defaultError),
+      success: () => Lazy.force(defaultValue),
       failure: e => e,
-      pending: () => Lazy.force(defaultError)
+      pending: () => Lazy.force(defaultValue)
     });
   }
 }

--- a/src/mut/loadable.ts
+++ b/src/mut/loadable.ts
@@ -173,7 +173,7 @@ export class Loadable<T> implements Future<T> {
    * @param defaultValue A possibly lazy value to use in case of non-success
    * @returns This Future's success value or the provided default value
    */
-  successOr(defaultValue: Lazy<T>): T {
+  successOr<U>(defaultValue: Lazy<U>): T | U {
     return this.match({
       success: v => v,
       failure: () => Lazy.force(defaultValue),


### PR DESCRIPTION
The two new methods `successOr` and `failureOr` can be thought of as shorthands of `match`: for example, `successOr` biases towards `success`, and thus will return the inner success value in the case of `success` or evaluate the supplied fallback in all other cases:

```ts
const n = f.successOr(4);
// equivalent to:
const n = f.match({
  success: v => v,
  failure: () => 4,
  pending: () => 4
});
```

The fallback value can be _lazy_:

```ts
const n = f.successOr(() => { /* expensive computation */ });
// equivalent to:
const n = f.match({
  success: v => v,
  failure: () => { /* expensive computation */ },
  pending: () => { /* expensive computation */ }
});
```

This laziness is encoded with the `Lazy<T>` type, defined as `T | (() => T)`, which is either an eagerly evaluated value or a [thunk](https://en.wikipedia.org/wiki/Thunk#Functional_programming). The outcome of a lazy value is generated with `Lazy.force`, which simply invokes the value and returns its result if the value is a thunk, or returns the value back as-is in all other cases.